### PR TITLE
Disable dlopen test

### DIFF
--- a/hatari/CMakeLists.txt
+++ b/hatari/CMakeLists.txt
@@ -220,7 +220,7 @@ check_symbol_exists(strlcpy "string.h" HAVE_LIBC_STRLCPY)
 check_struct_has_member("struct dirent" d_type dirent.h HAVE_DIRENT_D_TYPE)
 
 # hatariB - look for dlopen for CAPS dynamic load
-check_symbol_exists(dlopen "dlfcn.h" HAVE_DLOPEN)
+#check_symbol_exists(dlopen "dlfcn.h" HAVE_DLOPEN)
 
 # #############
 # Other CFLAGS:


### PR DESCRIPTION
Wondering if it's DLOPEN that prevents the RPi build from using -static-libgcc?