### PR TITLE
Savestate automatic comparison build test

### DIFF
--- a/core/core.c
+++ b/core/core.c
@@ -46,6 +46,11 @@ const uint64_t QUIRKS = RETRO_SERIALIZATION_QUIRK_ENDIAN_DEPENDENT;
 // Then run hatary_state_compare.py in your saves folder to compare the timelines.
 #define DEBUG_SAVESTATE_DUMP   0
 
+// Dumps a savestate to the saves folder X frames after starting the core content.
+// Intended for automated comparisons between versions, looking for cross-platform divergence.
+// When using this, disable host mouse and keyboard to prevent input divergence.
+#define DEBUG_SAVESTATE_DUMP_AUTO 1000
+
 // Simpler savestate integrity test: whenever a savestate is saved, it will store another state in X frames,
 // and then every savestate restore will compare its own state after X frames. 0 to disable.
 // Try to test with different delays, 1 frame, 10 frames, 100 frames, etc.
@@ -53,11 +58,10 @@ const uint64_t QUIRKS = RETRO_SERIALIZATION_QUIRK_ENDIAN_DEPENDENT;
 // (Usually the DIFF will indicate core_input in this case.)
 #define DEBUG_SAVESTATE_SIMPLE   0
 
-// Enable LIBRETRO_DEBUG_SNAPSHOT in memorySnapshot.c to list the the data locations and structure of snapshots.
 // Turn off hatarib_savestate_floppy_modify (Floppy Savestate Safety Save) in the core settings before testing savestates,
 // because it causes bContentsChanged divergence for any floppies that have save files.
 
-#define DEBUG_SAVESTATE   (DEBUG_SAVESTATE_DUMP | DEBUG_SAVESTATE_SIMPLE)
+#define DEBUG_SAVESTATE   (DEBUG_SAVESTATE_DUMP | DEBUG_SAVESTATE_DUMP_AUTO | DEBUG_SAVESTATE_SIMPLE)
 
 //
 // Libretro
@@ -638,6 +642,9 @@ static uint8_t* debug_snapshot_buffer = NULL;
 static int debug_snapshot_buffer_size = 0;
 static int debug_snapshot_countdown = 0;
 static bool debug_snapshot_read = false;
+#endif
+#if DEBUG_SAVESTATE_DUMP_AUTO
+static int debug_savestate_dump_auto = 0;
 #endif
 
 static void core_snapshot_open_internal(void)
@@ -1346,6 +1353,38 @@ RETRO_API void retro_run(void)
 		}
 	}
 #endif
+#if DEBUG_SAVESTATE_DUMP_AUTO
+	if (debug_savestate_dump_auto > 0)
+	{
+		--debug_savestate_dump_auto;
+		if (debug_savestate_dump_auto == 0)
+		{
+			snapshot_buffer_prepare(snapshot_size,NULL);
+			core_serialize(true);
+			char name[256] = "hatarib_auto_";
+			get_image_path(0,name+13,sizeof(name)-14);
+			strcat_trunc(name,".dump",sizeof(name));
+			corefile* f = core_file_open_save(name,CORE_FILE_WRITE);
+			if (f)
+			{
+				core_file_write(snapshot_buffer,1,snapshot_size,f);
+				// section pos/name suffix
+				for (int i=0; i<debug_snapshot_section_count; ++i)
+				{
+					core_file_write(&debug_snapshot_section_pos[i],sizeof(int),1,f);
+					int sl = 0;
+					if ((i+1) < debug_snapshot_section_count) sl = debug_snapshot_section_pos[i+1] - debug_snapshot_section_pos[i];
+					core_file_write(&sl,sizeof(int),1,f);
+					char pn[9] = "        ";
+					strcpy_trunc(pn,debug_snapshot_section_name[i],sizeof(pn));
+					core_file_write(pn,1,sizeof(pn)-1,f);
+				}
+				core_file_close(f);
+				core_signal_alert2("AUTO DUMP: ",name);
+			}
+		}
+	}
+#endif
 }
 
 RETRO_API size_t retro_serialize_size(void)
@@ -1437,6 +1476,10 @@ RETRO_API bool retro_load_game(const struct retro_game_info *game)
 		snapshot_size += (SNAPSHOT_ROUND - (snapshot_size % SNAPSHOT_ROUND));
 
 	retro_memory_maps();
+
+#if DEBUG_SAVESTATE_DUMP_AUTO
+	debug_savestate_dump_auto = DEBUG_SAVESTATE_DUMP_AUTO;
+#endif
 
 	return true;
 }

--- a/core/core.h
+++ b/core/core.h
@@ -36,6 +36,9 @@ extern uint8_t core_runflags;
 // PAUSE = user paused emulation
 // OSK = on-screen keyboard or other overlay active
 
+// this should be less than FILENAME_MAX used in configuration and floppy
+#define CORE_MAX_FILENAME   256
+
 // print to Libretro log
 extern void core_debug_msg(const char* msg);
 extern void core_debug_int(const char* msg, int num); // msg followed by num

--- a/core/core_disk.c
+++ b/core/core_disk.c
@@ -670,7 +670,7 @@ static bool set_initial_image(unsigned index, const char* path)
 	return false;
 }
 
-static bool get_image_path(unsigned index, char* path, size_t len)
+bool get_image_path(unsigned index, char* path, size_t len)
 {
 	//retro_log(RETRO_LOG_DEBUG,"get_image_path(%d,%p,%d)\n",index,path,(int)len);
 	if (index >= MAX_DISKS) return false;

--- a/core/core_disk.c
+++ b/core/core_disk.c
@@ -10,18 +10,17 @@
 #include "../hatari/src/includes/unzip.h"
 
 #define MAX_DISKS 32
-#define MAX_FILENAME 256
 
 struct disk_image
 {
 	// primary file
 	uint8_t* data;
 	unsigned int size;
-	char filename[MAX_FILENAME];
+	char filename[CORE_MAX_FILENAME];
 	// secondary file (used for STX save)
 	uint8_t* extra_data;
 	unsigned int extra_size;
-	char extra_filename[MAX_FILENAME];
+	char extra_filename[CORE_MAX_FILENAME];
 	// whether the file has a save
 	bool saved;
 };
@@ -115,7 +114,7 @@ static bool set_eject_state_drive(bool ejected, int d)
 		disks[image_index[d]].data, disks[image_index[d]].size,
 		disks[image_index[d]].extra_data, disks[image_index[d]].extra_size))
 	{
-		static char floppy_error_msg[MAX_FILENAME+256];
+		static char floppy_error_msg[CORE_MAX_FILENAME+256];
 		struct retro_message_ext msg;
 		snprintf(floppy_error_msg, sizeof(floppy_error_msg), "%c: disk failure: %s",d?'B':'A',disks[image_index[d]].filename);
 		msg.msg = floppy_error_msg;
@@ -505,7 +504,7 @@ static bool load_hard(const char* path, const char* filename, unsigned index, co
 {
 	retro_log(RETRO_LOG_INFO,"load_hard('%s','%s',%d,'%s')\n",path?path:"NULL",filename?filename:"NULL",index,ext);
 
-	strcpy_trunc(disks[index].filename,"<HD>",MAX_FILENAME);
+	strcpy_trunc(disks[index].filename,"<HD>",CORE_MAX_FILENAME);
 	strcat_trunc(disks[index].filename,filename,sizeof(disks[index].filename));
 
 	// find the base path
@@ -628,10 +627,10 @@ static bool replace_image_index(unsigned index, const struct retro_game_info* ga
 		}
 		if (ext && !strcasecmp(ext,"stx")) // STX has a secondary save file used as an overlay
 		{
-			strcpy_trunc(disks[index].extra_filename,path,MAX_FILENAME);
+			strcpy_trunc(disks[index].extra_filename,path,CORE_MAX_FILENAME);
 			int l = strlen(disks[index].extra_filename);
 			if (l >= 3) disks[index].extra_filename[l-3] = 0;
-			strcat_trunc(disks[index].extra_filename,"wd1772",MAX_FILENAME);
+			strcat_trunc(disks[index].extra_filename,"wd1772",CORE_MAX_FILENAME);
 			unsigned int extra_size = 0;
 			uint8_t* extra_data = core_read_file_save(disks[index].extra_filename,&extra_size);
 			if (extra_data != NULL)
@@ -699,7 +698,7 @@ static bool replace_image_index(unsigned index, const struct retro_game_info* ga
 	}
 	else
 	{
-		strcpy_trunc(disks[index].filename,path,MAX_FILENAME);
+		strcpy_trunc(disks[index].filename,path,CORE_MAX_FILENAME);
 	}
 	return true;
 }
@@ -1044,7 +1043,7 @@ bool core_disk_save(const char* filename, uint8_t* data, unsigned int size, bool
 
 void* disk_save_advanced_file = NULL;
 char disk_save_advanced_path[2048] = "";
-char disk_save_advanced_filename[MAX_FILENAME] = "";
+char disk_save_advanced_filename[CORE_MAX_FILENAME] = "";
 
 // buffer to 
 uint8_t* disk_save_advanced_buffer = NULL;

--- a/core/core_file.c
+++ b/core/core_file.c
@@ -10,7 +10,6 @@
 #include "core_internal.h"
 
 #define MAX_PATH          2048
-#define MAX_FILENAME      256
 #define MAX_SYSTEM_FILE   128
 #define MAX_SYSTEM_DIR     16
 
@@ -22,10 +21,10 @@
 #define CORE_FILE_DEBUG   0
 
 static int sf_count = 0;
-static char sf_filename[MAX_SYSTEM_FILE][MAX_FILENAME];
+static char sf_filename[MAX_SYSTEM_FILE][CORE_MAX_FILENAME];
 static int sf_dir_count = 0;
-static char sf_dirname[MAX_SYSTEM_DIR][MAX_FILENAME];
-static char sf_dirlabel[MAX_SYSTEM_DIR][MAX_FILENAME];
+static char sf_dirname[MAX_SYSTEM_DIR][CORE_MAX_FILENAME];
+static char sf_dirlabel[MAX_SYSTEM_DIR][CORE_MAX_FILENAME];
 
 struct retro_vfs_interface* retro_vfs = NULL;
 int retro_vfs_version = 0;
@@ -709,8 +708,8 @@ static void core_file_system_add(const char* filename, bool prefix_hatarib)
 	if (sf_count >= MAX_SYSTEM_FILE) return;
 	sf_filename[sf_count][0] = 0;
 	if (prefix_hatarib)
-		strcpy_trunc(sf_filename[sf_count],"hatarib/",MAX_FILENAME);
-	strcat_trunc(sf_filename[sf_count],filename,MAX_FILENAME);
+		strcpy_trunc(sf_filename[sf_count],"hatarib/",CORE_MAX_FILENAME);
+	strcat_trunc(sf_filename[sf_count],filename,CORE_MAX_FILENAME);
 	//retro_log(RETRO_LOG_DEBUG,"core_file_system_add: %s\n",sf_filename[sf_count]);
 	++sf_count;
 }
@@ -720,10 +719,10 @@ static void core_file_system_add_dir(const char* filename)
 	if (sf_dir_count >= MAX_SYSTEM_DIR) return;
 	if (!strcmp(filename,".")) return;
 	if (!strcmp(filename,"..")) return;
-	strcpy_trunc(sf_dirname[sf_dir_count],"hatarib/",MAX_FILENAME);
-	strcat_trunc(sf_dirname[sf_dir_count],filename,MAX_FILENAME);
-	strcpy_trunc(sf_dirlabel[sf_dir_count],filename,MAX_FILENAME);
-	strcat_trunc(sf_dirlabel[sf_dir_count],"/",MAX_FILENAME);
+	strcpy_trunc(sf_dirname[sf_dir_count],"hatarib/",CORE_MAX_FILENAME);
+	strcat_trunc(sf_dirname[sf_dir_count],filename,CORE_MAX_FILENAME);
+	strcpy_trunc(sf_dirlabel[sf_dir_count],filename,CORE_MAX_FILENAME);
+	strcat_trunc(sf_dirlabel[sf_dir_count],"/",CORE_MAX_FILENAME);
 	//retro_log(RETRO_LOG_DEBUG,"core_file_system_add_dir: %s\n",sf_filename[sf_count]);
 	++sf_dir_count;
 }

--- a/core/core_internal.h
+++ b/core/core_internal.h
@@ -97,6 +97,7 @@ extern void core_disk_drive_reinsert(void); // used after cold reboot
 extern void core_disk_swap(void); // convenience for: eject, next disk, insert
 
 extern unsigned get_num_images(void);
+extern bool get_image_path(unsigned index, char* label, size_t len);
 extern bool get_image_label(unsigned index, char* label, size_t len);
 
 // simple file save, as a complete buffer

--- a/hatari/src/configuration.c
+++ b/hatari/src/configuration.c
@@ -1137,41 +1137,73 @@ void Configuration_MemorySnapShot_Capture(bool bSave)
 {
 	int i;
 
+#ifndef __LIBRETRO__
 	MemorySnapShot_Store(ConfigureParams.Rom.szTosImageFileName, sizeof(ConfigureParams.Rom.szTosImageFileName));
 	MemorySnapShot_Store(ConfigureParams.Rom.szCartridgeImageFileName, sizeof(ConfigureParams.Rom.szCartridgeImageFileName));
 
 	MemorySnapShot_Store(ConfigureParams.Lilo.szKernelFileName, sizeof(ConfigureParams.Lilo.szKernelFileName));
 	MemorySnapShot_Store(ConfigureParams.Lilo.szRamdiskFileName, sizeof(ConfigureParams.Lilo.szRamdiskFileName));
+#else
+	MemorySnapShot_StoreFilename(ConfigureParams.Rom.szTosImageFileName, sizeof(ConfigureParams.Rom.szTosImageFileName));
+	MemorySnapShot_StoreFilename(ConfigureParams.Rom.szCartridgeImageFileName, sizeof(ConfigureParams.Rom.szCartridgeImageFileName));
+	// Lilo not supported
+#endif
 
 	MemorySnapShot_Store(&ConfigureParams.Memory.STRamSize_KB, sizeof(ConfigureParams.Memory.STRamSize_KB));
 	MemorySnapShot_Store(&ConfigureParams.Memory.TTRamSize_KB, sizeof(ConfigureParams.Memory.TTRamSize_KB));
 
+#ifndef __LIBRETRO__
 	MemorySnapShot_Store(&ConfigureParams.DiskImage.szDiskFileName[0], sizeof(ConfigureParams.DiskImage.szDiskFileName[0]));
 	MemorySnapShot_Store(&ConfigureParams.DiskImage.szDiskZipPath[0], sizeof(ConfigureParams.DiskImage.szDiskZipPath[0]));
+#else
+	MemorySnapShot_StoreFilename(ConfigureParams.DiskImage.szDiskFileName[0], sizeof(ConfigureParams.DiskImage.szDiskFileName[0]));
+	// DiskZip not used
+#endif
 	MemorySnapShot_Store(&ConfigureParams.DiskImage.EnableDriveA, sizeof(ConfigureParams.DiskImage.EnableDriveA));
 	MemorySnapShot_Store(&ConfigureParams.DiskImage.DriveA_NumberOfHeads, sizeof(ConfigureParams.DiskImage.DriveA_NumberOfHeads));
+#ifndef __LIBRETRO__
 	MemorySnapShot_Store(&ConfigureParams.DiskImage.szDiskFileName[1], sizeof(ConfigureParams.DiskImage.szDiskFileName[1]));
 	MemorySnapShot_Store(&ConfigureParams.DiskImage.szDiskZipPath[1], sizeof(ConfigureParams.DiskImage.szDiskZipPath[1]));
+#else
+	MemorySnapShot_StoreFilename(ConfigureParams.DiskImage.szDiskFileName[1], sizeof(ConfigureParams.DiskImage.szDiskFileName[1]));
+	// DiskZip not used
+#endif
 	MemorySnapShot_Store(&ConfigureParams.DiskImage.EnableDriveB, sizeof(ConfigureParams.DiskImage.EnableDriveB));
 	MemorySnapShot_Store(&ConfigureParams.DiskImage.DriveB_NumberOfHeads, sizeof(ConfigureParams.DiskImage.DriveB_NumberOfHeads));
 
 	MemorySnapShot_Store(&ConfigureParams.HardDisk.bUseHardDiskDirectories, sizeof(ConfigureParams.HardDisk.bUseHardDiskDirectories));
+#ifndef __LIBRETRO__
 	MemorySnapShot_Store(ConfigureParams.HardDisk.szHardDiskDirectories[DRIVE_C], sizeof(ConfigureParams.HardDisk.szHardDiskDirectories[DRIVE_C]));
+#else
+	MemorySnapShot_StoreFilename(ConfigureParams.HardDisk.szHardDiskDirectories[DRIVE_C], sizeof(ConfigureParams.HardDisk.szHardDiskDirectories[DRIVE_C]));
+#endif
 	for (i = 0; i < MAX_ACSI_DEVS; i++)
 	{
 		MemorySnapShot_Store(&ConfigureParams.Acsi[i].bUseDevice, sizeof(ConfigureParams.Acsi[i].bUseDevice));
+#ifndef __LIBRETRO__
 		MemorySnapShot_Store(ConfigureParams.Acsi[i].sDeviceFile, sizeof(ConfigureParams.Acsi[i].sDeviceFile));
+#else
+		MemorySnapShot_StoreFilename(ConfigureParams.Acsi[i].sDeviceFile, sizeof(ConfigureParams.Acsi[i].sDeviceFile));
+#endif
 	}
 	for (i = 0; i < MAX_SCSI_DEVS; i++)
 	{
 		MemorySnapShot_Store(&ConfigureParams.Scsi[i].bUseDevice, sizeof(ConfigureParams.Scsi[i].bUseDevice));
+#ifndef __LIBRETRO__
 		MemorySnapShot_Store(ConfigureParams.Scsi[i].sDeviceFile, sizeof(ConfigureParams.Scsi[i].sDeviceFile));
+#else
+		MemorySnapShot_StoreFilename(ConfigureParams.Scsi[i].sDeviceFile, sizeof(ConfigureParams.Scsi[i].sDeviceFile));
+#endif
 	}
 	for (i = 0; i < MAX_IDE_DEVS; i++)
 	{
 		MemorySnapShot_Store(&ConfigureParams.Ide[i].bUseDevice, sizeof(ConfigureParams.Ide[i].bUseDevice));
 		MemorySnapShot_Store(&ConfigureParams.Ide[i].nByteSwap, sizeof(ConfigureParams.Ide[i].nByteSwap));
+#ifndef __LIBRETRO__
 		MemorySnapShot_Store(ConfigureParams.Ide[i].sDeviceFile, sizeof(ConfigureParams.Ide[i].sDeviceFile));
+#else
+		MemorySnapShot_StoreFilename(ConfigureParams.Ide[i].sDeviceFile, sizeof(ConfigureParams.Ide[i].sDeviceFile));
+#endif
 	}
 
 	MemorySnapShot_Store(&ConfigureParams.Screen.nMonitorType, sizeof(ConfigureParams.Screen.nMonitorType));

--- a/hatari/src/floppy.c
+++ b/hatari/src/floppy.c
@@ -158,7 +158,11 @@ void Floppy_MemorySnapShot_Capture(bool bSave)
 		}
 		if (EmulationDrives[i].pBuffer)
 			MemorySnapShot_Store(EmulationDrives[i].pBuffer, EmulationDrives[i].nImageBytes);
+#ifndef __LIBRETRO__
 		MemorySnapShot_Store(EmulationDrives[i].sFileName, sizeof(EmulationDrives[i].sFileName));
+#else
+		MemorySnapShot_StoreFilename(EmulationDrives[i].sFileName, sizeof(EmulationDrives[i].sFileName));
+#endif
 		MemorySnapShot_Store(&EmulationDrives[i].bContentsChanged,sizeof(EmulationDrives[i].bContentsChanged));
 		MemorySnapShot_Store(&EmulationDrives[i].bOKToSave,sizeof(EmulationDrives[i].bOKToSave));
 		MemorySnapShot_Store(&EmulationDrives[i].TransitionState1,sizeof(EmulationDrives[i].TransitionState1));

--- a/hatari/src/includes/memorySnapShot.h
+++ b/hatari/src/includes/memorySnapShot.h
@@ -24,4 +24,17 @@ inline void MemorySnapShot_Store(void *pData, int Size)
 	if (bCaptureSave) core_snapshot_write(pData, Size);
   else              core_snapshot_read( pData, Size);
 }
+inline void MemorySnapShot_StoreFilename(char *pData, int Size)
+{
+  if (Size > CORE_MAX_FILENAME) Size = CORE_MAX_FILENAME;
+	if (bCaptureSave)
+  {
+    core_snapshot_write(pData, Size-1);
+  }
+  else
+  {
+    core_snapshot_read(pData, Size-1);
+    pData[Size-1] = 0;
+  }
+}
 #endif

--- a/hatari/src/memorySnapShot.c
+++ b/hatari/src/memorySnapShot.c
@@ -375,8 +375,6 @@ void MemorySnapShot_Capture_Immediate(const char *pszFileName, bool bConfirm)
  * Do the real saving (called from newcpu.c / m68k_go()
  */
 // use to figure out the structure of a snapshot (logs the start of each block in the savestate)
-//#define LIBRETRO_DEBUG_SNAPSHOT(x) core_debug_snapshot(x)
-#define LIBRETRO_DEBUG_SNAPSHOT(x) {}
 void MemorySnapShot_Capture_Do(void)
 {
 	Uint32 magic = SNAPSHOT_MAGIC;
@@ -384,6 +382,7 @@ void MemorySnapShot_Capture_Do(void)
 	/* Set to 'saving' */
 	if (MemorySnapShot_OpenFile(Temp_FileName, true, Temp_Confirm))
 	{
+#define LIBRETRO_DEBUG_SNAPSHOT(x) core_debug_snapshot(x)
 		/* Capture each files details */
 	LIBRETRO_DEBUG_SNAPSHOT("Configuration");
 		Configuration_MemorySnapShot_Capture(true);


### PR DESCRIPTION
This build will automatically dump an uncompressed and annotated savestate 1000 frames after loading content.

Setup:
1. Set default core options.
2. Set TOS to EmuTOS192k US.
3. Disable host keyboard, disable host mouse.

Load content (or start core) to open the game, don't press any inputs (use enter to load content to avoid pressing gamepad with the same key), wait for the dump notification after ~20 seconds. A file will be produced in the saves folder.