### PR TITLE
force HAVE_DLOPEN for raspberry pi builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,7 @@ jobs:
           path: artifact/
 
   build-ubuntu:
+    if: false
     name: Ubuntu Linux
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
 
   build-win64:
+  if: false
     name: Windows 64-bit
     runs-on: windows-latest
     steps:
@@ -61,6 +62,7 @@ jobs:
           path: artifact/
 
   build-win32:
+  if: false
     name: Windows 32-bit
     runs-on: windows-latest
     steps:
@@ -154,6 +156,7 @@ jobs:
           path: artifact/
 
   build-macos:
+  if: false
     name: MacOS Fat
     runs-on: macos-latest
     steps:
@@ -274,7 +277,7 @@ jobs:
       - name: Build hatariB
         run: |
           export CC=aarch64-linux-gnu-gcc
-          export CMAKEFLAGS="-DCMAKE_SYSTEM_NAME=aarch64-linux-gnu"
+          export CMAKEFLAGS="-DCMAKE_SYSTEM_NAME=aarch64-linux-gnu -DHAVE_DLOPEN=1"
           make
       - name: Prepare Artifact
         run: |
@@ -327,7 +330,7 @@ jobs:
       - name: Build hatariB
         run: |
           export CC=arm-linux-gnueabihf-gcc
-          export CMAKEFLAGS="-DCMAKE_SYSTEM_NAME=arm-linux-gnueabihf"
+          export CMAKEFLAGS="-DCMAKE_SYSTEM_NAME=arm-linux-gnueabihf -DHAVE_DLOPEN=1"
           make
         # CMAKE_SYSTEM_NAME informs cmake that we are cross-compiling, so that it knows to build and run cpugen natively.
       - name: Prepare Artifact
@@ -346,6 +349,7 @@ jobs:
           path: artifact/
 
   build-android64:
+  if: false
     name: Android 64-bit
     runs-on: ubuntu-latest
     steps:
@@ -410,6 +414,7 @@ jobs:
           path: artifact/
 
   build-android32:
+  if: false
     name: Android 32-bit
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
 
   build-win64:
-  if: false
+    if: false
     name: Windows 64-bit
     runs-on: windows-latest
     steps:
@@ -62,7 +62,7 @@ jobs:
           path: artifact/
 
   build-win32:
-  if: false
+    if: false
     name: Windows 32-bit
     runs-on: windows-latest
     steps:
@@ -156,7 +156,7 @@ jobs:
           path: artifact/
 
   build-macos:
-  if: false
+    if: false
     name: MacOS Fat
     runs-on: macos-latest
     steps:
@@ -349,7 +349,7 @@ jobs:
           path: artifact/
 
   build-android64:
-  if: false
+    if: false
     name: Android 64-bit
     runs-on: ubuntu-latest
     steps:
@@ -414,7 +414,7 @@ jobs:
           path: artifact/
 
   build-android32:
-  if: false
+    if: false
     name: Android 32-bit
     runs-on: ubuntu-latest
     steps:

--- a/hatari/src/floppy_ipf.c
+++ b/hatari/src/floppy_ipf.c
@@ -50,6 +50,7 @@ const char floppy_ipf_fileid[] = "Hatari floppy_ipf.c";
 #define __cdecl
 #ifdef HAVE_DLOPEN
 #include <dlfcn.h>
+#pragma message("dlfcn included")
 #endif
 #define SO_HANDLE void*
 #endif
@@ -679,6 +680,7 @@ static bool core_ipf_load(void)
 #ifdef HAVE_DLOPEN
 	capsHandle = dlopen(CAPS_SONAME, RTLD_NOW);
 	if (!capsHandle) core_error_msg(dlerror());
+	#pragma message("dlopen used")
 #else
 	core_error_msg("dlopen unavailable");
 #endif
@@ -697,6 +699,7 @@ static bool core_ipf_load(void)
 #else
 #ifdef HAVE_DLOPEN
 			dlsym(capsHandle, CAPSIMPORT[i].funcname);
+			#pragma message("dlsym used")
 #else
 			NULL;
 #endif
@@ -841,6 +844,7 @@ void	IPF_Exit ( void )
 		#else
 		#ifdef HAVE_DLOPEN
 			dlclose(capsHandle);
+			#pragma message("dlclose used")
 		#endif
 		#endif
 		capsHandle = NULL;


### PR DESCRIPTION
Test if this can be forced, even though cmake fails to find it, see #48 