### PR TITLE
Protect against redefinition of HAVE_CAPSIMAGE

### DIFF
--- a/hatari/src/floppy_ipf.c
+++ b/hatari/src/floppy_ipf.c
@@ -41,7 +41,9 @@ const char floppy_ipf_fileid[] = "Hatari floppy_ipf.c";
 #else
 
 // dynamically link with CAPSIMAGE library at runtime instead of implicitly linking it into the build
+#ifndef HAVE_CAPSIMAGE
 #define HAVE_CAPSIMAGE
+#endif
 
 #ifdef WIN32
 #include <windows.h>


### PR DESCRIPTION
When `HAVE_CAPSIMAGE` has been defined because CMake has found `capsimage`, the `#define HAVE_CAPSIMAGE` in _floppy_ipf.c_ to allow dynamic loading causes compilation issues.

Protect against this  by checking if `HAVE_CAPSIMAGE` has been defined first.