### PR TITLE
libretro: fix call to core_prevent_eject_save / core_debug_printf

### DIFF
--- a/hatari/src/floppy.c
+++ b/hatari/src/floppy.c
@@ -788,7 +788,7 @@ bool Floppy_EjectDiskFromDrive(int Drive)
 	EmulationDrives[Drive].ImageType = FLOPPY_IMAGE_TYPE_NONE;
 	EmulationDrives[Drive].nImageBytes = 0;
 	EmulationDrives[Drive].bDiskInserted = false;
-#ifndef __LIBRETRO__
+#ifdef __LIBRETRO__
 	if (!core_prevent_eject_save)
 #endif
 	EmulationDrives[Drive].bContentsChanged = false;

--- a/hatari/src/gemdos.c
+++ b/hatari/src/gemdos.c
@@ -839,7 +839,7 @@ void GemDOS_InitDrives(void)
 			return;
 		}
 	}
-#ifndef __LIBRETRO__
+#ifdef __LIBRETRO__
 	core_debug_printf("GemDOS drives: %d\n",nMaxDrives);
 #endif
 


### PR DESCRIPTION
core_prevent_eject_save and core_debug_printf are only declared if __LIBRETRO__ defined? Fixes compiling on GCC 16.2

here: 

```
#ifdef __LIBRETRO__
extern bool core_savestate_floppy_modify;
static bool core_prevent_eject_save = false;
#endif
```

There is also one more issue, core_input.c has a dependency on sdl. That's a bigger change, preferably SDL needs to be #ifndef __LIBRETRO__ completely, so it can be distributed as a libretro core eventually.