### PR TITLE
Fix the libretro Windows cross builds

### DIFF
--- a/makefile.libretro
+++ b/makefile.libretro
@@ -21,17 +21,17 @@ else ifeq ($(platform),osx)
 ifneq ($(ARCH),arm)                             # osx-x64
 else                                            # osx-arm64
 endif
-else ifeq ($(ANDROID_PLATFORM),android_arm)     # android-make: android-arm
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake
+else ifeq ($(ANDROID_PLATFORM),android-arm)     # android-make: android-arm
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake
 	COREFILE := $(CORENAME)_libretro_android
-else ifeq ($(ANDROID_PLATFORM),android_arm64)   # android-make: android-arm64
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake
+else ifeq ($(ANDROID_PLATFORM),android-arm64)   # android-make: android-arm64
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake
 	COREFILE := $(CORENAME)_libretro_android
-else ifeq ($(ANDROID_PLATFORM),android_x86)     # android-make: android-x86
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake
+else ifeq ($(ANDROID_PLATFORM),android-x86)     # android-make: android-x86
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake
 	COREFILE := $(CORENAME)_libretro_android
-else ifeq ($(ANDROID_PLATFORM),android_x86_64)  # android-make: android-x86_64
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$NDK_ROOT/build/cmake/android.toolchain.cmake
+else ifeq ($(ANDROID_PLATFORM),android-x86_64)  # android-make: android-x86_64
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake
 	COREFILE := $(CORENAME)_libretro_android
 else ifeq ($(platform),ios-arm64)               # ios-arm64
 	COREFILE := $(CORENAME)_libretro_ios


### PR DESCRIPTION
Rebased on main. Four commits, each independent.

**CMAKE_FLAGS.** `makefile.libretro` passes `CMAKE_FLAGS=-DCMAKE_SYSTEM_NAME=Windows` for the two mingw cross builds, but the makefile only reads `CMAKEFLAGS`, so it was dropped and cmake still believed it was building for the host. Passing `CMAKEFLAGS` on the command line instead would override the makefile's own assignments and take the zlib, SDL2 and find-package flags with it, so `CMAKEFLAGS += $(CMAKE_FLAGS)` is the way in.

Verified by running what the two templates run, with `CC` and `platform` in the environment the way the ci-templates pass them ([run](https://github.com/WizzardSK/hatariB/actions/runs/33988763939)): both arches come out as `hatarib_libretro.dll`, `PE32+ executable (DLL) x86-64` and `PE32 executable (DLL) Intel 80386`. That run is on a current cmake; the MXE image's is 3.10.2 against hatari's 3.12 minimum, which is a separate problem this PR does not solve.

**PIC.** Everything linked into a shared object has to be position independent. x86-64 gets away without it; webOS armv7a does not, and job 2226390 fails on `relocation R_ARM_MOVW_ABS_NC against a local symbol ... recompile with -fPIC` in `libDebug.a`. `CFLAGS` carries `-fPIC` for the core's own objects, but the cmake sub-build does not inherit it for its targets. `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` does, and the job then builds ([run](https://github.com/WizzardSK/hatariB/actions/runs/33988435014), same SDK the image carries).

**Core names.** `libretro-build-ios-arm64`, `libretro-build-ios9` and `libretro-build-tvos-arm64` pass on the buildbot and ship nothing: their templates upload `${CORENAME}_libretro_ios.dylib` and `${CORENAME}_libretro_tvos.dylib`, the makefile builds `hatarib_libretro.dylib`, and an `after_script` that cannot find its file does not fail the job.

```
mv: rename ./hatarib_libretro_ios.dylib to hatarib_libretro_ios.dylib: No such file or directory
WARNING: after_script failed, but job will continue unaffected
WARNING: hatarib_libretro_ios.dylib: no matching files.
```

So each of those cases sets `COREFILE`, and `android-make`, which wants `${CORENAME}_libretro_android.so`, gets it too. The four android cases also never matched at all: the template's `ANDROID_PLATFORM` values are `android-arm`, `android-arm64`, `android-x86`, `android-x86_64`, with hyphens.

**Job set.** The three MSVC jobs still extend `.libretro-windows-*-msvc*-msys2-*`, whose templates are no longer in `include:` — as it stands the configuration references three templates that do not exist, which is a config error for the whole pipeline, not just those jobs. Dropped, along with the console, handheld and emscripten jobs whose images carry cmake 3.7.2. webOS goes back in, since with the PIC commit it produces a core. What is left is the same 18 platforms libretro/hatari builds, with `android-make` in place of its `android-jni`.

That last commit is the one to drop if you would rather keep the jobs while you work through them — it is separate for that reason.
