### PR TITLE
Fix the android, Wii U, emscripten and console buildbot jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,8 @@
 # Notes:
 #
 # Some platforms have out-of-date versions of cmake.
-# These will fetch cmake 3.31.6 and place it on the path.
+# These will fetch cmake 3.31.6 and place it on the path. It goes to /tmp
+# rather than /opt: the console images do not run the job as root.
 #   windows-x64
 #   windows-i686
 #   ctr (3DS)
@@ -17,6 +18,10 @@
 #  psl1ght (PS3)
 #  libnx-aarch64 (Switch)
 #
+# Submodules are checked out by CI rather than by the makefile: the build
+# directory is shared between jobs and .git is not writable from the images
+# that run as a non-root user.
+#
 # More info: https://github.com/bbbradsmith/hatariB/pull/81
 
 ##############################################################################
@@ -29,6 +34,7 @@
     JNI_PATH: .
     CORENAME: hatarib
     MAKEFILE: makefile.libretro
+    GIT_SUBMODULE_STRATEGY: recursive
 
 # Inclusion templates, required for the build to work
 include:
@@ -144,8 +150,8 @@ libretro-build-windows-x64:
     - !reference [.libretro-windows-x64-mingw, before_script]
     - |
       CMAKE_VER=3.31.6
-      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /opt
-      export PATH="/opt/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
+      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /tmp
+      export PATH="/tmp/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
 
 # Windows 32-bit
 libretro-build-windows-i686:
@@ -156,8 +162,8 @@ libretro-build-windows-i686:
     - !reference [.libretro-windows-i686-mingw, before_script]
     - |
       CMAKE_VER=3.31.6
-      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /opt
-      export PATH="/opt/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
+      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /tmp
+      export PATH="/tmp/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
 
 # Linux 64-bit
 libretro-build-linux-x64:
@@ -278,8 +284,8 @@ libretro-build-ctr:
     - !reference [.libretro-ctr-static, before_script]
     - |
       CMAKE_VER=3.31.6
-      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /opt
-      export PATH="/opt/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
+      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /tmp
+      export PATH="/tmp/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
 
 # Nintendo GameCube
 libretro-build-ngc:
@@ -290,8 +296,8 @@ libretro-build-ngc:
     - !reference [.libretro-ngc-static, before_script]
     - |
       CMAKE_VER=3.31.6
-      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /opt
-      export PATH="/opt/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
+      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /tmp
+      export PATH="/tmp/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
 
 # Nintendo Wii
 libretro-build-wii:
@@ -302,8 +308,8 @@ libretro-build-wii:
     - !reference [.libretro-wii-static, before_script]
     - |
       CMAKE_VER=3.31.6
-      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /opt
-      export PATH="/opt/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
+      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /tmp
+      export PATH="/tmp/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
 
 # Nintendo WiiU
 libretro-build-wiiu:

--- a/makefile.libretro
+++ b/makefile.libretro
@@ -7,6 +7,13 @@ MAKEACTION ?= core
 MAKEEXTRA ?=
 CMAKEFLAGS_EXTRA ?=
 
+# The android-make template hands us NDK_ROOT and ANDROID_NDK_LLVM but no
+# compiler. cmake gets one from the NDK toolchain file; the core's own
+# objects and the final link do not, and would fall back to the host gcc.
+ANDROID_NDK_LLVM ?= $(NDK_ROOT)/toolchains/llvm/prebuilt/linux-x86_64
+# fseeko/ftello, used by hatari's avi_record.c, arrive in API 24.
+ANDROID_API ?= 24
+
 ifeq ($(platform),win64)                        # windows-x64-mingw
 	CMAKEFLAGS_EXTRA := -DCMAKE_SYSTEM_NAME=Windows
 	MAKEEXTRA := SO_SUFFIX=.dll
@@ -22,17 +29,33 @@ ifneq ($(ARCH),arm)                             # osx-x64
 else                                            # osx-arm64
 endif
 else ifeq ($(ANDROID_PLATFORM),android-arm)     # android-make: android-arm
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake \
+		-DANDROID_ABI=armeabi-v7a -DANDROID_PLATFORM=android-$(ANDROID_API)
 	COREFILE := $(CORENAME)_libretro_android
+	MAKEEXTRA := CC="$(ANDROID_NDK_LLVM)/bin/clang --target=armv7a-linux-androideabi$(ANDROID_API)" \
+		AR=$(ANDROID_NDK_LLVM)/bin/llvm-ar \
+		RANLIB=$(ANDROID_NDK_LLVM)/bin/llvm-ranlib
 else ifeq ($(ANDROID_PLATFORM),android-arm64)   # android-make: android-arm64
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake \
+		-DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-$(ANDROID_API)
 	COREFILE := $(CORENAME)_libretro_android
+	MAKEEXTRA := CC="$(ANDROID_NDK_LLVM)/bin/clang --target=aarch64-linux-android$(ANDROID_API)" \
+		AR=$(ANDROID_NDK_LLVM)/bin/llvm-ar \
+		RANLIB=$(ANDROID_NDK_LLVM)/bin/llvm-ranlib
 else ifeq ($(ANDROID_PLATFORM),android-x86)     # android-make: android-x86
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake \
+		-DANDROID_ABI=x86 -DANDROID_PLATFORM=android-$(ANDROID_API)
 	COREFILE := $(CORENAME)_libretro_android
+	MAKEEXTRA := CC="$(ANDROID_NDK_LLVM)/bin/clang --target=i686-linux-android$(ANDROID_API)" \
+		AR=$(ANDROID_NDK_LLVM)/bin/llvm-ar \
+		RANLIB=$(ANDROID_NDK_LLVM)/bin/llvm-ranlib
 else ifeq ($(ANDROID_PLATFORM),android-x86_64)  # android-make: android-x86_64
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake \
+		-DANDROID_ABI=x86_64 -DANDROID_PLATFORM=android-$(ANDROID_API)
 	COREFILE := $(CORENAME)_libretro_android
+	MAKEEXTRA := CC="$(ANDROID_NDK_LLVM)/bin/clang --target=x86_64-linux-android$(ANDROID_API)" \
+		AR=$(ANDROID_NDK_LLVM)/bin/llvm-ar \
+		RANLIB=$(ANDROID_NDK_LLVM)/bin/llvm-ranlib
 else ifeq ($(platform),ios-arm64)               # ios-arm64
 	COREFILE := $(CORENAME)_libretro_ios
 else ifeq ($(platform),ios9)                    # ios9
@@ -48,21 +71,25 @@ else ifeq ($(platform),psp1)                    # psp-static
 else ifeq ($(platform),vita)                    # vita-static
 	MAKEACTION := static
 else ifeq ($(platform),ctr)                     # ctr-static
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEKVITPRO)/cmake/3DS.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/3DS.cmake
 	MAKEACTION := static
 else ifeq ($(platform),ngc)                     # ngc-static
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEKVITPRO)/cmake/GameCube.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/GameCube.cmake
 	MAKEACTION := static
 else ifeq ($(platform),wii)                     # wii-static
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEKVITPRO)/cmake/Wii.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/Wii.cmake
 	MAKEACTION := static
 else ifeq ($(platform),wiiu)                    # wiiu-static
-	#CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEKVITPRO)/cmake/WiiU.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/WiiU.cmake
 	MAKEACTION := static
 else ifeq ($(platform),libnx)                   # libnx-static
-	#CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEKVITPRO)/cmake/NintendoSwitch.cmake
+	#CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/NintendoSwitch.cmake
 	MAKEACTION := static
 else ifeq ($(platform),emscripten)              # emscripten-static
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(EMSDK)/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake
+	# emscripten's clang warns about set-but-unused globals in hatari's own
+	# sources, which -Werror then turns into a failed build
+	MAKEEXTRA := WERROR=
 	MAKEACTION := static
 	CORESTATIC_SUFFIX := .bc
 endif
@@ -77,5 +104,5 @@ MAKEARGS = $(MAKEACTION) \
 	CMAKEFLAGS_EXTRA="$(CMAKEFLAGS_EXTRA)"
 
 libretro:
-	$(MAKE) -f makefile zlib
+	$(MAKE) -f makefile zlib $(MAKEEXTRA)
 	$(MAKE) -f makefile $(MAKEARGS)

--- a/makefile.zlib
+++ b/makefile.zlib
@@ -1,5 +1,8 @@
 ZLIB_BUILD ?= zlib_build
 ZLIB_PREFIX = $(PWD)/$(ZLIB_BUILD)
+CC ?= cc
+AR ?= ar
+RANLIB ?= ranlib
 CFLAGS += -fPIC
 # -fPIC needed to link into a shared object
 
@@ -9,9 +12,14 @@ submodules:
 	git submodule init
 	git submodule update --depth 1
 
+# zlib's configure takes its compiler from the environment. It has to be the
+# same one the core is built with, or the static library it leaves behind is
+# for the host and the core does not link (android, and any other target
+# whose compiler is not the default cc).
 $(ZLIB_BUILD)/lib/libz.a: submodules
 	mkdir -p $(ZLIB_BUILD)
-	cd $(ZLIB_BUILD) && export CFLAGS="$(CFLAGS)" && ../zlib/configure --static --prefix=$(ZLIB_PREFIX)
+	cd $(ZLIB_BUILD) && export CFLAGS="$(CFLAGS)" CC="$(CC)" AR="$(AR)" RANLIB="$(RANLIB)" \
+		&& ../zlib/configure --static --prefix=$(ZLIB_PREFIX)
 	cd $(ZLIB_BUILD) && $(MAKE) static
 	cd $(ZLIB_BUILD) && $(MAKE) install
 

--- a/makefile.zlib
+++ b/makefile.zlib
@@ -8,9 +8,16 @@ CFLAGS += -fPIC
 
 default: $(ZLIB_BUILD)/lib/libz.a
 
+# The buildbot reuses one build directory for every job, and the console
+# images do not all run as the user that owns that checkout, so git cannot
+# write .git/modules there. Nothing needs writing when the submodule is
+# already in place - CI checks it out for us, see GIT_SUBMODULE_STRATEGY.
 submodules:
-	git submodule init
-	git submodule update --depth 1
+	@if [ -e zlib/configure ]; then \
+		echo "zlib submodule already checked out"; \
+	else \
+		git submodule init && git submodule update --depth 1; \
+	fi
 
 # zlib's configure takes its compiler from the environment. It has to be the
 # same one the core is built with, or the static library it leaves behind is


### PR DESCRIPTION
Last night's buildbot pipeline (`main`, `d4ea6b8`) is red on 11 of 25 jobs. They fall into three groups, and this fixes the first two.

**Nothing tells four targets what they are building for.**

- **android** (all four jobs): only the NDK toolchain file goes to cmake, so the NDK picks its own default ABI — every job builds armeabi-v7a, the arm64 job included — and its default API level, where bionic declares no `fseeko`/`ftello` and `hatari/src/avi_record.c` fails with eight `call to undeclared function` errors. Nothing gives the core's own objects or the final link a compiler either, so those used the host `gcc`; zlib too. Now each case passes its `ANDROID_ABI`, `-DANDROID_PLATFORM=android-24`, and the NDK clang for the triple, and `makefile.zlib` builds libz with the same compiler.
- **wiiu**: `CMAKE_TOOLCHAIN_FILE` is commented out, so the core is built for the host and RetroArch's link skips it — `skipping incompatible ./libretro_wiiu.a when searching for -lretro_wiiu`.
- **ctr, ngc, wii**: the toolchain file is `$(DEKVITPRO)/cmake/...`, and that variable is empty; the images export `DEVKITPRO`.
- **emscripten**: no toolchain file, so cmake does not think it is cross compiling and hatari builds `build68k`/`gencpu` with emcc, then cannot run them — `./build68k: Permission denied`. Its clang also rejects hatari's set-but-unused globals under `-Werror`, so that comes off for this target.

**Five console jobs never reach a compiler, because the job is not root.**

- **ps2, psp, vita, psl1ght, libnx**: `makefile.zlib` runs `git submodule init/update` and gets `could not lock config file .git/modules/zlib/config: Permission denied`. The runner reuses one build directory across jobs, `.git` belongs to the jobs that do run as root, and `safe.directory` does not help — that is git's ownership check, not the filesystem's. CI now checks the submodule out (`GIT_SUBMODULE_STRATEGY: recursive`) and the makefile skips the git call when it is already there.
- **ctr, ngc, wii**: the cmake 3.31.6 fetch unpacks into `/opt`, which only the windows containers can write — `tar: cmake-3.31.6-linux-x86_64: Cannot mkdir: Permission denied`. It goes to `/tmp` now.

**Verified** on GitHub Actions before sending, in [this workflow](https://github.com/WizzardSK/hatarib-libretro/blob/preflight-buildbot/.github/workflows/preflight-buildbot.yml) (branch `preflight-buildbot` on my fork, not part of this PR): the four android ABIs build and `file` reports the ABI each job asked for; emscripten produces its `.bc`; a build with `.git` made read-only completes; the cmake fetch runs as a user who cannot write `/opt`.

**What this does not fix.** With the toolchain files in place, the devkitPro targets get to hatari's own sources and stop there:

```
hatari/src/gemdos.c:244:24: error: storage size of 'timebuf' isn't known
hatari/src/gemdos.c:286:13: error: implicit declaration of function 'utime'
hatari/src/cpu/fpp_softfloat.c:697:56: error: passing argument 2 of 'floatx80_to_floatdecimal' from incompatible pointer type   (ctr)
```

devkitPro's newlib has no `utime.h`, and its gcc also turns several of hatari's warnings into errors. That is a porting job in the hatari tree rather than a CI one, so ctr, ngc, wii and wiiu stay red after this — for a reason that is now visible instead of hidden behind a host build.