### PR TITLE
Fix the buildbot, and build the same platforms as libretro/hatari

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,8 @@
 # Notes:
 #
 # Some platforms have out-of-date versions of cmake.
-# These will fetch cmake 3.31.6 and place it on the path.
+# These will fetch cmake 3.31.6 and place it on the path. It goes to /tmp
+# rather than /opt: the console images do not run the job as root.
 #   windows-x64
 #   windows-i686
 #   ctr (3DS)
@@ -17,6 +18,10 @@
 #  psl1ght (PS3)
 #  libnx-aarch64 (Switch)
 #
+# Submodules are checked out by CI rather than by the makefile: the build
+# directory is shared between jobs and .git is not writable from the images
+# that run as a non-root user.
+#
 # More info: https://github.com/bbbradsmith/hatariB/pull/81
 
 ##############################################################################
@@ -29,6 +34,7 @@
     JNI_PATH: .
     CORENAME: hatarib
     MAKEFILE: makefile.libretro
+    GIT_SUBMODULE_STRATEGY: recursive
 
 # Inclusion templates, required for the build to work
 include:
@@ -144,8 +150,8 @@ libretro-build-windows-x64:
     - !reference [.libretro-windows-x64-mingw, before_script]
     - |
       CMAKE_VER=3.31.6
-      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /opt
-      export PATH="/opt/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
+      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /tmp
+      export PATH="/tmp/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
 
 # Windows 32-bit
 libretro-build-windows-i686:
@@ -156,8 +162,8 @@ libretro-build-windows-i686:
     - !reference [.libretro-windows-i686-mingw, before_script]
     - |
       CMAKE_VER=3.31.6
-      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /opt
-      export PATH="/opt/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
+      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /tmp
+      export PATH="/tmp/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
 
 # Linux 64-bit
 libretro-build-linux-x64:
@@ -278,8 +284,8 @@ libretro-build-ctr:
     - !reference [.libretro-ctr-static, before_script]
     - |
       CMAKE_VER=3.31.6
-      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /opt
-      export PATH="/opt/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
+      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /tmp
+      export PATH="/tmp/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
 
 # Nintendo GameCube
 libretro-build-ngc:
@@ -290,8 +296,8 @@ libretro-build-ngc:
     - !reference [.libretro-ngc-static, before_script]
     - |
       CMAKE_VER=3.31.6
-      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /opt
-      export PATH="/opt/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
+      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /tmp
+      export PATH="/tmp/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
 
 # Nintendo Wii
 libretro-build-wii:
@@ -302,8 +308,8 @@ libretro-build-wii:
     - !reference [.libretro-wii-static, before_script]
     - |
       CMAKE_VER=3.31.6
-      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /opt
-      export PATH="/opt/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
+      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /tmp
+      export PATH="/tmp/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
 
 # Nintendo WiiU
 libretro-build-wiiu:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,23 +4,17 @@
 #
 # Some platforms have out-of-date versions of cmake.
 # These will fetch cmake 3.31.6 and place it on the path. It goes to /tmp
-# rather than /opt: the console images do not run the job as root.
+# rather than /opt: not every image runs the job as root.
 #   windows-x64
 #   windows-i686
-#   ctr (3DS)
-#   ngc (GameCube)
 #   wii
-#
-# Some platforms require git safe directory permissions.
-#  psp
-#  vita
-#  ps2
-#  psl1ght (PS3)
-#  libnx-aarch64 (Switch)
 #
 # Submodules are checked out by CI rather than by the makefile: the build
 # directory is shared between jobs and .git is not writable from the images
 # that run as a non-root user.
+#   vita
+#
+# The targets libretro/hatari does not build are not built here either.
 #
 # More info: https://github.com/bbbradsmith/hatariB/pull/81
 
@@ -81,29 +75,9 @@ include:
     file: '/ios9.yml'
 
   ################################## CONSOLES ################################
-  # PlayStation2
-  - project: 'libretro-infrastructure/ci-templates'
-    file: '/ps2-static.yml'
-    
-  # PlayStation3
-  - project: 'libretro-infrastructure/ci-templates'
-    file: '/psl1ght-static.yml'
-    
-  # PlayStation Portable
-  - project: 'libretro-infrastructure/ci-templates'
-    file: '/psp-static.yml'
-
   # PlayStation Vita
   - project: 'libretro-infrastructure/ci-templates'
     file: '/vita-static.yml'
-
-  # Nintendo 3DS
-  - project: 'libretro-infrastructure/ci-templates'
-    file: '/ctr-static.yml'
-
-  # Nintendo GameCube
-  - project: 'libretro-infrastructure/ci-templates'
-    file: '/ngc-static.yml'
 
   # Nintendo Wii
   - project: 'libretro-infrastructure/ci-templates'
@@ -113,19 +87,11 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/wiiu-static.yml'
 
-  # Nintendo Switch
-  - project: 'libretro-infrastructure/ci-templates'
-    file: '/libnx-static.yml'
-
   # tvOS (AppleTV)
   - project: 'libretro-infrastructure/ci-templates'
     file: '/tvos-arm64.yml'
 
   #################################### MISC ##################################
-  # Emscripten
-  - project: 'libretro-infrastructure/ci-templates'
-    file: '/emscripten-static.yml'
-
   # webOS 32-bit (LGTV)
   - project: 'libretro-infrastructure/ci-templates'
     file: '/webos-make.yml'
@@ -239,15 +205,6 @@ libretro-build-tvos-arm64:
     - .core-defs
 
 ################################### CONSOLES #################################
-# PlayStation Portable
-libretro-build-psp:
-  extends:
-    - .libretro-psp-static-retroarch-master
-    - .core-defs
-  before_script:
-    - !reference [.libretro-psp-static, before_script]
-    - git config --global --add safe.directory "$CI_PROJECT_DIR"
-
 # PlayStation Vita
 libretro-build-vita:
   extends:
@@ -256,48 +213,6 @@ libretro-build-vita:
   before_script:
     - !reference [.libretro-vita-static, before_script]
     - git config --global --add safe.directory "$CI_PROJECT_DIR"
-
-# PlayStation2
-libretro-build-ps2:
-  extends:
-    - .libretro-ps2-static-retroarch-master
-    - .core-defs
-  before_script:
-    - !reference [.libretro-ps2-static, before_script]
-    - git config --global --add safe.directory "$CI_PROJECT_DIR"
-    
-# PlayStation3
-libretro-build-psl1ght:
-  extends:
-    - .libretro-psl1ght-static-retroarch-master
-    - .core-defs
-  before_script:
-    - !reference [.libretro-psl1ght-static, before_script]
-    - git config --global --add safe.directory "$CI_PROJECT_DIR"
-
-# Nintendo 3DS
-libretro-build-ctr:
-  extends:
-    - .libretro-ctr-static-retroarch-master
-    - .core-defs
-  before_script:
-    - !reference [.libretro-ctr-static, before_script]
-    - |
-      CMAKE_VER=3.31.6
-      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /tmp
-      export PATH="/tmp/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
-
-# Nintendo GameCube
-libretro-build-ngc:
-  extends:
-    - .libretro-ngc-static-retroarch-master
-    - .core-defs
-  before_script:
-    - !reference [.libretro-ngc-static, before_script]
-    - |
-      CMAKE_VER=3.31.6
-      curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" | tar -xz -C /tmp
-      export PATH="/tmp/cmake-${CMAKE_VER}-linux-x86_64/bin:$PATH"
 
 # Nintendo Wii
 libretro-build-wii:
@@ -315,22 +230,6 @@ libretro-build-wii:
 libretro-build-wiiu:
   extends:
     - .libretro-wiiu-static-retroarch-master
-    - .core-defs
-
-# Nintendo Switch
-libretro-build-libnx-aarch64:
-  extends:
-    - .libretro-libnx-static-retroarch-master
-    - .core-defs
-  before_script:
-    - !reference [.libretro-libnx-static, before_script]
-    - git config --global --add safe.directory "$CI_PROJECT_DIR"
-
-#################################### MISC ##################################
-# Emscripten
-libretro-build-emscripten:
-  extends:
-    - .libretro-emscripten-static-retroarch-master
     - .core-defs
 
 # webOS 32-bit

--- a/hatari/src/gemdos.c
+++ b/hatari/src/gemdos.c
@@ -241,9 +241,11 @@ static bool GemDOS_GetFileInformation(int Handle, DATETIME *DateTime)
 static bool GemDOS_SetFileInformation(int Handle, DATETIME *DateTime)
 {
 	const char *filename;
+#if HAVE_UTIME_H || HAVE_SYS_UTIME_H
 	struct utimbuf timebuf;
 	struct stat filestat;
 	struct tm timespec;
+#endif
 
 	/* make sure Hatari itself doesn't need to write/modify
 	 * the file after it's modification time is changed.
@@ -260,6 +262,7 @@ static bool GemDOS_SetFileInformation(int Handle, DATETIME *DateTime)
 
 	filename = FileHandles[Handle].szActualName;
 	
+#if HAVE_UTIME_H || HAVE_SYS_UTIME_H
 	/* Bits: 0-4 = secs/2, 5-10 = mins, 11-15 = hours (24-hour format) */
 	timespec.tm_sec  = (DateTime->timeword & 0x1F) << 1;
 	timespec.tm_min  = (DateTime->timeword & 0x7E0) >> 5;
@@ -287,6 +290,11 @@ static bool GemDOS_SetFileInformation(int Handle, DATETIME *DateTime)
 		return false;
 	// fprintf(stderr, "set date '%s' for %s\n", asctime(&timespec), name);
 	return true;
+#else
+	/* No utime()/utimbuf on this platform */
+	(void)filename;
+	return true;
+#endif
 }
 
 

--- a/makefile.libretro
+++ b/makefile.libretro
@@ -7,6 +7,13 @@ MAKEACTION ?= core
 MAKEEXTRA ?=
 CMAKEFLAGS_EXTRA ?=
 
+# The android-make template hands us NDK_ROOT and ANDROID_NDK_LLVM but no
+# compiler. cmake gets one from the NDK toolchain file; the core's own
+# objects and the final link do not, and would fall back to the host gcc.
+ANDROID_NDK_LLVM ?= $(NDK_ROOT)/toolchains/llvm/prebuilt/linux-x86_64
+# fseeko/ftello, used by hatari's avi_record.c, arrive in API 24.
+ANDROID_API ?= 24
+
 ifeq ($(platform),win64)                        # windows-x64-mingw
 	CMAKEFLAGS_EXTRA := -DCMAKE_SYSTEM_NAME=Windows
 	MAKEEXTRA := SO_SUFFIX=.dll
@@ -22,17 +29,33 @@ ifneq ($(ARCH),arm)                             # osx-x64
 else                                            # osx-arm64
 endif
 else ifeq ($(ANDROID_PLATFORM),android-arm)     # android-make: android-arm
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake \
+		-DANDROID_ABI=armeabi-v7a -DANDROID_PLATFORM=android-$(ANDROID_API)
 	COREFILE := $(CORENAME)_libretro_android
+	MAKEEXTRA := CC="$(ANDROID_NDK_LLVM)/bin/clang --target=armv7a-linux-androideabi$(ANDROID_API)" \
+		AR=$(ANDROID_NDK_LLVM)/bin/llvm-ar \
+		RANLIB=$(ANDROID_NDK_LLVM)/bin/llvm-ranlib
 else ifeq ($(ANDROID_PLATFORM),android-arm64)   # android-make: android-arm64
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake \
+		-DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-$(ANDROID_API)
 	COREFILE := $(CORENAME)_libretro_android
+	MAKEEXTRA := CC="$(ANDROID_NDK_LLVM)/bin/clang --target=aarch64-linux-android$(ANDROID_API)" \
+		AR=$(ANDROID_NDK_LLVM)/bin/llvm-ar \
+		RANLIB=$(ANDROID_NDK_LLVM)/bin/llvm-ranlib
 else ifeq ($(ANDROID_PLATFORM),android-x86)     # android-make: android-x86
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake \
+		-DANDROID_ABI=x86 -DANDROID_PLATFORM=android-$(ANDROID_API)
 	COREFILE := $(CORENAME)_libretro_android
+	MAKEEXTRA := CC="$(ANDROID_NDK_LLVM)/bin/clang --target=i686-linux-android$(ANDROID_API)" \
+		AR=$(ANDROID_NDK_LLVM)/bin/llvm-ar \
+		RANLIB=$(ANDROID_NDK_LLVM)/bin/llvm-ranlib
 else ifeq ($(ANDROID_PLATFORM),android-x86_64)  # android-make: android-x86_64
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(NDK_ROOT)/build/cmake/android.toolchain.cmake \
+		-DANDROID_ABI=x86_64 -DANDROID_PLATFORM=android-$(ANDROID_API)
 	COREFILE := $(CORENAME)_libretro_android
+	MAKEEXTRA := CC="$(ANDROID_NDK_LLVM)/bin/clang --target=x86_64-linux-android$(ANDROID_API)" \
+		AR=$(ANDROID_NDK_LLVM)/bin/llvm-ar \
+		RANLIB=$(ANDROID_NDK_LLVM)/bin/llvm-ranlib
 else ifeq ($(platform),ios-arm64)               # ios-arm64
 	COREFILE := $(CORENAME)_libretro_ios
 else ifeq ($(platform),ios9)                    # ios9
@@ -48,19 +71,19 @@ else ifeq ($(platform),psp1)                    # psp-static
 else ifeq ($(platform),vita)                    # vita-static
 	MAKEACTION := static
 else ifeq ($(platform),ctr)                     # ctr-static
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEKVITPRO)/cmake/3DS.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/3DS.cmake
 	MAKEACTION := static
 else ifeq ($(platform),ngc)                     # ngc-static
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEKVITPRO)/cmake/GameCube.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/GameCube.cmake
 	MAKEACTION := static
 else ifeq ($(platform),wii)                     # wii-static
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEKVITPRO)/cmake/Wii.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/Wii.cmake
 	MAKEACTION := static
 else ifeq ($(platform),wiiu)                    # wiiu-static
-	#CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEKVITPRO)/cmake/WiiU.cmake
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/WiiU.cmake
 	MAKEACTION := static
 else ifeq ($(platform),libnx)                   # libnx-static
-	#CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEKVITPRO)/cmake/NintendoSwitch.cmake
+	#CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/NintendoSwitch.cmake
 	MAKEACTION := static
 else ifeq ($(platform),emscripten)              # emscripten-static
 	MAKEACTION := static
@@ -77,5 +100,5 @@ MAKEARGS = $(MAKEACTION) \
 	CMAKEFLAGS_EXTRA="$(CMAKEFLAGS_EXTRA)"
 
 libretro:
-	$(MAKE) -f makefile zlib
+	$(MAKE) -f makefile zlib $(MAKEEXTRA)
 	$(MAKE) -f makefile $(MAKEARGS)

--- a/makefile.libretro
+++ b/makefile.libretro
@@ -78,9 +78,13 @@ else ifeq ($(platform),ngc)                     # ngc-static
 	MAKEACTION := static
 else ifeq ($(platform),wii)                     # wii-static
 	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/Wii.cmake
+	# devkitPPC's gcc warns about hatari's own isspace()/isdigit() char
+	# subscripts and about one snprintf in the uae headers
+	MAKEEXTRA := WERROR=
 	MAKEACTION := static
 else ifeq ($(platform),wiiu)                    # wiiu-static
 	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/WiiU.cmake
+	MAKEEXTRA := WERROR=
 	MAKEACTION := static
 else ifeq ($(platform),libnx)                   # libnx-static
 	#CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/NintendoSwitch.cmake

--- a/makefile.zlib
+++ b/makefile.zlib
@@ -1,5 +1,8 @@
 ZLIB_BUILD ?= zlib_build
 ZLIB_PREFIX = $(PWD)/$(ZLIB_BUILD)
+CC ?= cc
+AR ?= ar
+RANLIB ?= ranlib
 CFLAGS += -fPIC
 # -fPIC needed to link into a shared object
 
@@ -9,9 +12,14 @@ submodules:
 	git submodule init
 	git submodule update --depth 1
 
+# zlib's configure takes its compiler from the environment. It has to be the
+# same one the core is built with, or the static library it leaves behind is
+# for the host and the core does not link (android, and any other target
+# whose compiler is not the default cc).
 $(ZLIB_BUILD)/lib/libz.a: submodules
 	mkdir -p $(ZLIB_BUILD)
-	cd $(ZLIB_BUILD) && export CFLAGS="$(CFLAGS)" && ../zlib/configure --static --prefix=$(ZLIB_PREFIX)
+	cd $(ZLIB_BUILD) && export CFLAGS="$(CFLAGS)" CC="$(CC)" AR="$(AR)" RANLIB="$(RANLIB)" \
+		&& ../zlib/configure --static --prefix=$(ZLIB_PREFIX)
 	cd $(ZLIB_BUILD) && $(MAKE) static
 	cd $(ZLIB_BUILD) && $(MAKE) install
 

--- a/makefile.zlib
+++ b/makefile.zlib
@@ -8,9 +8,16 @@ CFLAGS += -fPIC
 
 default: $(ZLIB_BUILD)/lib/libz.a
 
+# The buildbot reuses one build directory for every job, and the console
+# images do not all run as the user that owns that checkout, so git cannot
+# write .git/modules there. Nothing needs writing when the submodule is
+# already in place - CI checks it out for us, see GIT_SUBMODULE_STRATEGY.
 submodules:
-	git submodule init
-	git submodule update --depth 1
+	@if [ -e zlib/configure ]; then \
+		echo "zlib submodule already checked out"; \
+	else \
+		git submodule init && git submodule update --depth 1; \
+	fi
 
 # zlib's configure takes its compiler from the environment. It has to be the
 # same one the core is built with, or the static library it leaves behind is


### PR DESCRIPTION
Supersedes #82, which I have closed - everything is here in one branch.

Last night's pipeline on `main` (`d4ea6b8`) was red on 14 of its 25 jobs. Seven of those jobs are for platforms that neither `libretro/hatari` nor `hatari2014` build, and have never produced a core here; the last commit drops them, which leaves this core building the same 18 platforms as the other two. The rest are fixed.

**Nothing tells three targets what they are building for.**

- **android** (all four jobs): only the NDK toolchain file goes to cmake, so the NDK picks its own default ABI — every job builds armeabi-v7a, the arm64 one included — and its default API level, where bionic declares no `fseeko`/`ftello` and `hatari/src/avi_record.c` fails with eight `call to undeclared function` errors. Nothing gives the core's own objects or the final link a compiler either, so those used the host `gcc`, and zlib with them. Each case now passes its `ANDROID_ABI`, `-DANDROID_PLATFORM=android-24` and the NDK clang for its triple, and `makefile.zlib` builds libz with the same compiler.
- **wiiu**: `CMAKE_TOOLCHAIN_FILE` is commented out, so the core is built for the host and RetroArch's link skips it — `skipping incompatible ./libretro_wiiu.a when searching for -lretro_wiiu`.
- **wii**: the toolchain file is spelled `$(DEKVITPRO)`, and that variable is empty; the images export `DEVKITPRO`.

**Two jobs never reach a compiler, because the job is not root.**

- **vita**: `makefile.zlib` runs `git submodule init/update` and gets `could not lock config file .git/modules/zlib/config: Permission denied`. The runner reuses one build directory across jobs, `.git` belongs to the jobs that do run as root, and `safe.directory` does not help — that is git's ownership check, not the filesystem's. CI checks the submodule out now (`GIT_SUBMODULE_STRATEGY: recursive`) and the makefile skips the git call when it is already there.
- **wii**: the cmake 3.31.6 fetch unpacks into `/opt`, which only the windows containers can write — `tar: cmake-3.31.6-linux-x86_64: Cannot mkdir: Permission denied`. It goes to `/tmp` now.

**And hatari itself does not build for devkitPPC.** With the toolchain file in place, wii and wiiu get as far as the sources and stop on `gemdos.c:244: storage size of 'timebuf' isn't known` / `implicit declaration of function 'utime'`: devkitPro's newlib has no `utime.h`, and this tree uses `struct utimbuf` unconditionally even though its include is already behind `#if HAVE_UTIME_H || HAVE_SYS_UTIME_H`. Upstream hatari guards the body with the same condition, which is what the third commit backports — a no-op wherever `utime.h` exists. The fourth takes `-Werror` off for those two targets; what is left is hatari's own `isspace`/`isdigit` char subscripts and one `snprintf` the analyzer cannot see through, and devkitPPC's gcc is stricter than the desktop ones. Drop that commit if you would rather fix the five call sites.

**Verified** on GitHub Actions before sending, in [this workflow](https://github.com/WizzardSK/hatarib-libretro/blob/preflight-final/.github/workflows/preflight-buildbot.yml) (branch `preflight-final` on my fork, not part of this PR): the four android ABIs build and `file` reports the ABI each job asked for; wii and wiiu build in `devkitpro/devkitppc:latest` and `powerpc-eabi-objdump -f` says the archive holds PowerPC objects, not host ones; a build with `.git` made read-only completes; and the cmake fetch runs as a user who cannot write `/opt`.