### PR TITLE
libretro: build the console cores with the console's toolchain

### DIFF
--- a/makefile.libretro
+++ b/makefile.libretro
@@ -64,9 +64,24 @@ else ifeq ($(platform),vita)                    # vita-static
 	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(VITASDK)/share/vita.toolchain.cmake
 	# readcpu.c opcstr[pos] (char-subscripts)
 	CFLAGS_EXTRA := -Wno-char-subscripts
+	# The toolchain file only reaches the CMake half of the build; the core's
+	# own objects and zlib go through this makefile, and without a compiler
+	# they come out x86 - which the link only notices as "file format not
+	# recognized" when RetroArch pulls the archive in.
+	MAKE_EXTRA := CC="$(VITASDK)/bin/arm-vita-eabi-gcc" \
+		AR="$(VITASDK)/bin/arm-vita-eabi-ar" \
+		RANLIB="$(VITASDK)/bin/arm-vita-eabi-ranlib"
 	MAKEACTION := static
 else ifeq ($(platform),wii)                     # wii-static
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/wii.cmake
+	# -DHAVE_FLOCK= for the same reason as wiiu below: newlib has no flock,
+	# but a toolchain that cannot link a plain test executable leaves CMake
+	# checking the declaration only, and hatari's file.c then calls it.
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/wii.cmake -DHAVE_FLOCK=
+	# That toolchain file names the compiler without a path, so CMake's own
+	# compiler check fails ("is not a full path and was not found in the PATH")
+	# unless devkitPPC's bin is on PATH. Passing CC below is not enough: the
+	# toolchain file is read again for every check and sets its own value.
+	export PATH := $(DEVKITPPC)/bin:$(PATH)
 	# readcpu.c opcstr[pos] (char-subscripts)
 	CFLAGS_EXTRA := -Wno-char-subscripts
 	MAKE_EXTRA := CC="${DEVKITPPC}/bin/powerpc-eabi-gcc" \
@@ -76,7 +91,12 @@ else ifeq ($(platform),wii)                     # wii-static
 else ifeq ($(platform),wiiu)                    # wiiu-static
 	# libretro WiiU does not appear to have a toolchain file, settings from libretro-wiiu-static-cmake
 	CMAKEFLAGS_EXTRA :=  -DCMAKE_SYSTEM_PROCESSOR=powerpc -DCMAKE_SYSTEM_NAME=Generic \
-		-DCMAKE_CROSSCOMPILING=ON -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DCMAKE_POSITION_INDEPENDENT_CODE=OFF
+		-DCMAKE_CROSSCOMPILING=ON -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DCMAKE_POSITION_INDEPENDENT_CODE=OFF \
+		-DHAVE_FLOCK=
+	# TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY means CMake's feature checks
+	# compile but never link, so check_symbol_exists(flock) finds newlib's
+	# declaration and says yes; hatari's file.c then calls a function that is
+	# not in the library, and RetroArch's link is where it surfaces.
 	# readcpu.c opcstr[pos] (char-subscripts)
 	CFLAGS_EXTRA := -mcpu=750 -meabi -mhard-float \
 		-Wno-char-subscripts
@@ -88,6 +108,12 @@ else ifeq ($(platform),libnx)                   # libnx-static
 	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/Switch.cmake
 	# readcpu.c opcstr[pos] (char-subscripts)
 	CFLAGS_EXTRA := -Wno-char-subscripts
+	# As with vita: the toolchain file covers the CMake half only, so name the
+	# compiler for the core's own objects and for zlib as well, or the archive
+	# comes out x86 and the link says "Relocations in generic ELF (EM: 62)".
+	MAKE_EXTRA := CC="$(DEVKITPRO)/devkitA64/bin/aarch64-none-elf-gcc" \
+		AR="$(DEVKITPRO)/devkitA64/bin/aarch64-none-elf-ar" \
+		RANLIB="$(DEVKITPRO)/devkitA64/bin/aarch64-none-elf-ranlib"
 	MAKEACTION := static
 endif
 


### PR DESCRIPTION
Last night's buildbot pipeline (109780, `bb5bf18`) is 15/19: **vita, wii, wiiu and libnx** fail. Three distinct causes, one file.

### vita and libnx: the archive is x86

The toolchain file passed in `CMAKEFLAGS_EXTRA` reaches the CMake half of the build — the hatari library — but the core's own objects and zlib go through `makefile`, where `CC ?= gcc` picks the host compiler. RetroArch then links against an archive full of x86 objects:

```
/opt/vitasdk/arm-vita-eabi/bin/ld: ./libretro_vita.a: error adding symbols: file format not recognized
...aarch64-none-elf/bin/ld: libretro_libnx.a(core.o): Relocations in generic ELF (EM: 62)
```

So name the compiler for them too, the way `android`, `wii` and `wiiu` already do.

### wii: CMake cannot find the compiler

```
The CMAKE_C_COMPILER:
    powerpc-eabi-gcc
  is not a full path and was not found in the PATH.
```

`/opt/devkitpro/wii.cmake` names the compiler without a path. `MAKE_EXTRA CC=...` does not help — the toolchain file is re-read for every one of CMake's checks and sets its own value each time — so devkitPPC's `bin` goes on `PATH` instead.

### wii and wiiu: flock()

```
libretro_wiiu.a(file.c.obj): in function `File_Lock': undefined reference to `flock'
```

hatari guards that call with `check_symbol_exists(flock "sys/file.h" HAVE_FLOCK)`. The check compiles a program and links it — except on a toolchain that cannot link a plain executable, where CMake settles for compiling. newlib **declares** `flock`; it does not have it. wiiu gets there through `CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY` in the flags here, wii through its toolchain file, and both end up with `HAVE_FLOCK` defined and a call to a function that is not in the library. `-DHAVE_FLOCK=` pre-seeds the cache, which `check_symbol_exists` leaves alone.

### Verification

All four built in the nearest public toolchain containers — `devkitpro/devkitppc`, `devkitpro/devkita64`, `vitasdk/vitasdk` — and each archive checked for its architecture and for any remaining reference to `flock`:

| target | archive | `nm -u \| grep flock` |
|---|---|---|
| wii | `elf32-powerpc` | nothing |
| wiiu | `elf32-powerpc` | nothing |
| vita | `elf32-littlearm` | nothing |
| libnx | `elf64-littleaarch64` | nothing |

One caveat worth knowing for anyone repeating that: those containers carry a much newer devkitPPC than the buildbot's gcc 12.1, and it stops on a `-Werror=format-overflow` in `hatari/src/cpu/uae/string.h` (`_stprintf` into a possibly-null pointer, from `disasm.c`) which the buildbot never reports — the check builds ran with `WERROR=-Wall` for that reason. It may be worth keeping in mind separately if devkitPro's gcc ever lands on the buildbot.