### PR TITLE
Fix the three remaining console builds: wii, vita and libnx

### DIFF
--- a/hatari/src/cpu/fpp_native.c
+++ b/hatari/src/cpu/fpp_native.c
@@ -22,7 +22,21 @@
 #include "hatari-glue.h"
 #endif
 
+/* The host rounding path calls fesetround with the four C99 rounding modes.
+ * devkitPPC's newlib has a <fenv.h> that declares fesetround but defines none
+ * of those modes, so on the Wii this does not compile:
+ *
+ *   error: 'FE_TONEAREST' undeclared (first use in this function)
+ *
+ * Deciding from the modes themselves rather than from a platform name keeps
+ * this right for any other libc with the same gap. The USE_HOST_ROUNDING == 0
+ * path below is complete - it rounds with floor, ceil and round instead. */
+#if defined(FE_TONEAREST) && defined(FE_TOWARDZERO) && \
+	defined(FE_DOWNWARD) && defined(FE_UPWARD)
 #define USE_HOST_ROUNDING 1
+#else
+#define USE_HOST_ROUNDING 0
+#endif
 #define SOFTFLOAT_CONVERSIONS 1
 
 #include "options_cpu.h"

--- a/makefile.libretro
+++ b/makefile.libretro
@@ -64,9 +64,24 @@ else ifeq ($(platform),vita)                    # vita-static
 	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(VITASDK)/share/vita.toolchain.cmake
 	# readcpu.c opcstr[pos] (char-subscripts)
 	CFLAGS_EXTRA := -Wno-char-subscripts
+	# The toolchain file only reaches the CMake half of the build; the core's
+	# own objects and zlib go through this makefile, and without a compiler
+	# they come out x86 - which the link only notices as "file format not
+	# recognized" when RetroArch pulls the archive in.
+	MAKE_EXTRA := CC="$(VITASDK)/bin/arm-vita-eabi-gcc" \
+		AR="$(VITASDK)/bin/arm-vita-eabi-ar" \
+		RANLIB="$(VITASDK)/bin/arm-vita-eabi-ranlib"
 	MAKEACTION := static
 else ifeq ($(platform),wii)                     # wii-static
-	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/wii.cmake
+	# -DHAVE_FLOCK= for the same reason as wiiu below: newlib has no flock,
+	# but a toolchain that cannot link a plain test executable leaves CMake
+	# checking the declaration only, and hatari's file.c then calls it.
+	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/wii.cmake -DHAVE_FLOCK=
+	# That toolchain file names the compiler without a path, so CMake's own
+	# compiler check fails ("is not a full path and was not found in the PATH")
+	# unless devkitPPC's bin is on PATH. Passing CC below is not enough: the
+	# toolchain file is read again for every check and sets its own value.
+	export PATH := $(DEVKITPPC)/bin:$(PATH)
 	# readcpu.c opcstr[pos] (char-subscripts)
 	CFLAGS_EXTRA := -Wno-char-subscripts
 	MAKE_EXTRA := CC="${DEVKITPPC}/bin/powerpc-eabi-gcc" \
@@ -76,7 +91,12 @@ else ifeq ($(platform),wii)                     # wii-static
 else ifeq ($(platform),wiiu)                    # wiiu-static
 	# libretro WiiU does not appear to have a toolchain file, settings from libretro-wiiu-static-cmake
 	CMAKEFLAGS_EXTRA :=  -DCMAKE_SYSTEM_PROCESSOR=powerpc -DCMAKE_SYSTEM_NAME=Generic \
-		-DCMAKE_CROSSCOMPILING=ON -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DCMAKE_POSITION_INDEPENDENT_CODE=OFF
+		-DCMAKE_CROSSCOMPILING=ON -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DCMAKE_POSITION_INDEPENDENT_CODE=OFF \
+		-DHAVE_FLOCK=
+	# TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY means CMake's feature checks
+	# compile but never link, so check_symbol_exists(flock) finds newlib's
+	# declaration and says yes; hatari's file.c then calls a function that is
+	# not in the library, and RetroArch's link is where it surfaces.
 	# readcpu.c opcstr[pos] (char-subscripts)
 	CFLAGS_EXTRA := -mcpu=750 -meabi -mhard-float \
 		-Wno-char-subscripts
@@ -88,6 +108,12 @@ else ifeq ($(platform),libnx)                   # libnx-static
 	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/Switch.cmake
 	# readcpu.c opcstr[pos] (char-subscripts)
 	CFLAGS_EXTRA := -Wno-char-subscripts
+	# As with vita: the toolchain file covers the CMake half only, so name the
+	# compiler for the core's own objects and for zlib as well, or the archive
+	# comes out x86 and the link says "Relocations in generic ELF (EM: 62)".
+	MAKE_EXTRA := CC="$(DEVKITPRO)/devkitA64/bin/aarch64-none-elf-gcc" \
+		AR="$(DEVKITPRO)/devkitA64/bin/aarch64-none-elf-ar" \
+		RANLIB="$(DEVKITPRO)/devkitA64/bin/aarch64-none-elf-ranlib"
 	MAKEACTION := static
 endif
 

--- a/makefile.libretro
+++ b/makefile.libretro
@@ -71,6 +71,14 @@ else ifeq ($(platform),vita)                    # vita-static
 	MAKE_EXTRA := CC="$(VITASDK)/bin/arm-vita-eabi-gcc" \
 		AR="$(VITASDK)/bin/arm-vita-eabi-ar" \
 		RANLIB="$(VITASDK)/bin/arm-vita-eabi-ranlib"
+	# zlib's own makefile adds -fPIC because a shared core needs it. This core
+	# is static, and on the Vita -fPIC produces R_ARM_GOT_BREL relocations that
+	# vita-elf-create cannot represent: the core and hatari build, the archive
+	# is fine, and RetroArch's link then ends with "Invalid relocation type
+	# 25!". Nothing else here is built PIC - the CMake half has
+	# POSITION_INDEPENDENT_CODE=OFF and the core's own objects never had it -
+	# so zlib was the only source of them.
+	ZLIB_EXTRA := ZLIB_FPIC=
 	MAKEACTION := static
 else ifeq ($(platform),wii)                     # wii-static
 	# -DHAVE_FLOCK= for the same reason as wiiu below: newlib has no flock,
@@ -107,7 +115,15 @@ else ifeq ($(platform),wiiu)                    # wiiu-static
 else ifeq ($(platform),libnx)                   # libnx-static
 	CMAKEFLAGS_EXTRA := -DCMAKE_TOOLCHAIN_FILE=$(DEVKITPRO)/cmake/Switch.cmake
 	# readcpu.c opcstr[pos] (char-subscripts)
-	CFLAGS_EXTRA := -Wno-char-subscripts
+	#
+	# -fPIE because everything on the Switch is: devkitA64's switch_rules puts
+	# it in ARCH for exactly this reason. Without it these objects carry
+	# absolute relocations, and RetroArch's final link - which is a PIE - has
+	# to place them in .text, which the linker refuses with "read-only segment
+	# has dynamic relocations". The core and hatari build cleanly and the
+	# archive is produced; only that last link fails. This reaches both halves,
+	# since CFLAGS_EXTRA is part of CMAKE_C_FLAGS as well.
+	CFLAGS_EXTRA := -Wno-char-subscripts -fPIE
 	# As with vita: the toolchain file covers the CMake half only, so name the
 	# compiler for the core's own objects and for zlib as well, or the archive
 	# comes out x86 and the link says "Relocations in generic ELF (EM: 62)".

--- a/makefile.zlib
+++ b/makefile.zlib
@@ -4,8 +4,13 @@ CFLAGS_EXTRA ?=
 CC ?= cc
 AR ?= ar
 RANLIB ?= ranlib
-CFLAGS += -fPIC $(CFLAGS_EXTRA)
-# -fPIC needed to link into a shared object
+# -fPIC needed to link into a shared object. A static console core is not one:
+# it becomes a .a that RetroArch links into its own executable, and there -fPIC
+# is at best unnecessary and at worst fatal. On the Vita it is fatal - it makes
+# gcc emit R_ARM_GOT_BREL, and vita-elf-create refuses the result with
+# "Invalid relocation type 25!". Platforms that need it off set ZLIB_FPIC= .
+ZLIB_FPIC ?= -fPIC
+CFLAGS += $(ZLIB_FPIC) $(CFLAGS_EXTRA)
 
 default: $(ZLIB_BUILD)/lib/libz.a
 


### PR DESCRIPTION
The last three red jobs in the pipeline. Each fails for its own reason, and two of them build the core perfectly well and then fall over in RetroArch's link — so the logs are a bit misleading about where the problem is.

## Wii

```
fpp_native.c:195:16: error: 'FE_TONEAREST' undeclared (first use in this function)
```

and the same for `FE_TOWARDZERO`, `FE_DOWNWARD` and `FE_UPWARD`. devkitPPC's newlib ships a `<fenv.h>` that declares `fesetround` but defines none of the rounding modes it takes.

`USE_HOST_ROUNDING` was `1` unconditionally; it now depends on those four macros existing, which keeps it right for any other libc with the same gap rather than singling out the Wii. The `USE_HOST_ROUNDING == 0` path is complete — it rounds with `floor`, `ceil` and `round`.

**Tested:** I forced that path on in a native build, with `-Werror`, and the file compiles and the core links.

## Vita

```
vita-elf-create: Invalid relocation type 25!
```

25 is `R_ARM_GOT_BREL`, which is what `-fPIC` makes gcc emit, and `vita-elf-create` cannot represent it. The only source of PIC in this build is zlib — `makefile.zlib` adds `-fPIC` with the comment *"needed to link into a shared object"*, which a static console core is not: it becomes a `.a` that RetroArch links into its own executable. Nothing else is PIC; the CMake half already has `POSITION_INDEPENDENT_CODE=OFF` and the core's own objects never had it.

`ZLIB_FPIC` lets a platform turn it off, and the Vita block does.

## Switch

```
ld: read-only segment has dynamic relocations
```

when linking `retroarch_switch.elf`. Everything on the Switch is position-independent — devkitA64's `switch_rules` puts `-fPIE` in `ARCH` — but the core's objects were compiled without it, so they carry absolute relocations that a PIE link has nowhere to put. `-fPIE` goes into `CFLAGS_EXTRA`, which reaches the core's own objects and the CMake half alike, since it is part of `CMAKE_C_FLAGS` too.

## What is and is not verified

The Wii change is tested as described. The desktop build is unchanged and still links — zlib still gets `-fPIC` there, I checked the flag both ways.

The two console changes I could not test: there is no vitasdk or devkitA64 on this machine. Both follow from the error text and from what the rest of each build already does, but the buildbot is what will actually confirm them. Worth knowing before merging rather than after.